### PR TITLE
Stop images and iframes breaking the layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -27,6 +27,11 @@ body, input, select, textarea {
 	line-height: 1.75em;
 }
 
+img,
+iframe {
+  max-width: 100%;
+}
+
 #content {
   padding: 2em;
   background: rgba(35, 31, 32, 0.5);


### PR DESCRIPTION
I noticed that the images broke the layout when viewed on a phone. This stops that happening.